### PR TITLE
FAKE_SERIAL fix with autodetect code

### DIFF
--- a/Makefile.win
+++ b/Makefile.win
@@ -4,7 +4,7 @@
 
 BV=$(shell (git rev-list HEAD --count))
 BD=$(shell (date))
-CFLAGS=-O -DBUILD_VER="$(BV)"  -DBUILD_DATE=\""$(BD)"\"
+CFLAGS=-O -DBUILD_VER="$(BV)" -DBUILD_DATE=\""$(BD)"\" -DFAKE_SERIAL=$(FAKE_SERIAL)
 LIBS=
 WINLIBS=-lgdi32 -lcomdlg32 -lcomctl32 -lmingw32 -lwinspool
 CC=gcc

--- a/win-bk390a.cpp
+++ b/win-bk390a.cpp
@@ -670,7 +670,11 @@ int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, PWSTR lpCmdLin
    /*
 	 * Handle the COM Port
 	 */
+#if FAKE_SERIAL == 1
+	if (0) {
+#else 
 	if (g.com_address == DEFAULT_COM_PORT) { // no port was specified, so attempt an auto-detect
+#endif
       if(g.debug) {
          wprintf(L"Now attempting an auto-detect....\r\n");
       }


### PR DESCRIPTION
Two simple changes
1) I forgot to add CFLAGS into Makefile.win.  Sorry!
2) FAKE_SERIAL was still attempting to autodetect a port and exit with error. So I disabled autodetect with #if macros just like you did for the rest of the code.